### PR TITLE
Fix class string of required properties

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1287,7 +1287,7 @@ simpleRef = function(name) {
 Property.prototype.toString = function() {
   var str = getStringSignature(this.schema);
   if(str !== '') {
-    str = '<span class="propName ' + this.required + '">' + this.name + '</span> (<span class="propType">' + str + '</span>';
+    str = '<span class="propName ' + (this.required ? 'required' : '') + '">' + this.name + '</span> (<span class="propType">' + str + '</span>';
     if(this.obj && this.obj.readOnly)
       str += ', <span class="propReadOnlyKey">read-only</span>';
     if(this.required)


### PR DESCRIPTION
HTML emitted for type signature of required properties included "false" in the element class.  This PR fixes that to emit "required" in the class string instead.