### PR TITLE
Support link navigations within doc

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -78,6 +78,10 @@
       setInterval(function(){window.updateLoginButton()}, 5000);
       $('#login').mouseenter(function(){window.updateLoginButton()});
 
+      window.onhashchange = function () {
+        Docs.shebang();
+      }
+
       window.swaggerUi.load();
   });
   </script>

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -78,6 +78,10 @@
       setInterval(function(){window.updateLoginButton()}, 5000);
       $('#login').mouseenter(function(){window.updateLoginButton()});
 
+      window.onhashchange = function () {
+        Docs.shebang();
+      }
+
       window.swaggerUi.load();
   });
   </script>


### PR DESCRIPTION
Add support for <a> links in swagger doc to link to other topics within the same doc.

Basically, hook `window.onhashchange` to perform the existing expand-and-slide-into-view behavior currently done at page load.