### PR TITLE
Fix missing read-only label on some properties

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -1287,7 +1287,7 @@ Property.prototype.toString = function() {
   var str = getStringSignature(this.schema);
   if(str !== '') {
     str = '<span class="propName ' + (this.required ? 'required' : '') + '">' + this.name + '</span> (<span class="propType">' + str + '</span>';
-    if(this.obj && this.obj.readOnly)
+    if(this.schema && this.schema.readOnly)
       str += ', <span class="propReadOnlyKey">read-only</span>';
     if(this.required)
       str += ', <span class="propRequredKey">required</span>';

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1287,7 +1287,7 @@ Property.prototype.toString = function() {
   var str = getStringSignature(this.schema);
   if(str !== '') {
     str = '<span class="propName ' + (this.required ? 'required' : '') + '">' + this.name + '</span> (<span class="propType">' + str + '</span>';
-    if(this.obj && this.obj.readOnly)
+    if(this.schema && this.schema.readOnly)
       str += ', <span class="propReadOnlyKey">read-only</span>';
     if(this.required)
       str += ', <span class="propRequredKey">required</span>';


### PR DESCRIPTION
Test case: Update_user, role_ids property should be displayed as read-only, but wasn't.