### PR TITLE
Add x-looker-appid header in API Explorer API requests

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -30,7 +30,8 @@
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
 
   <script type="text/javascript">
-    const DEFAULT_API_VERSION_URL = "/versions";
+    const API_VERSION_URL = "/versions";
+    const LOOKER_APPID_HEADER = Object.freeze({'x-looker-appid': 'Looker API Explorer'});
 
     function loadSwaggerUI(api_versioned_swagger_url) {
       return new Promise(function (resolve, reject) {
@@ -38,6 +39,7 @@
           url: api_versioned_swagger_url,
           dom_id: "swagger-ui-container",
           supportedSubmitMethods: ['get', 'post', 'put', 'patch', 'delete'],
+          headers: LOOKER_APPID_HEADER,
           // This onComplete will also be called by subsequent
           // swaggerUi.updateSwaggerUi calls
           onComplete: function(swaggerApi, swaggerUi){
@@ -80,13 +82,14 @@
       $('#login').mouseenter(function(){window.updateLoginButton()});
 
       new Promise(function (resolve, reject) {
-        return fetch(DEFAULT_API_VERSION_URL)
-          .then(function (response) {
-            if (response.status == '404')
-              reject(response.statusText);
-            else
-              resolve(response.json());
-          })
+        return fetch(API_VERSION_URL, {
+          headers: Object.assign({}, LOOKER_APPID_HEADER),
+        }).then(function (response) {
+          if (response.status === 404)
+            reject(response.statusText);
+          else
+            resolve(response.json());
+        })
       }).then(function(versionJson) {
         window.swagger_versions = versionJson.supported_versions.reduce((hash, v) => {
           hash[v.version] = v

--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -313,6 +313,8 @@ var SwaggerClient = function(url, options) {
   if (options.url != null)
     this.url = options.url;
 
+  this.headers = options.headers;
+
   if (options.success != null)
     this.success = options.success;
 
@@ -340,9 +342,7 @@ SwaggerClient.prototype.build = function() {
     useXHR: this.useXHR,
     url: this.url,
     method: "get",
-    headers: {
-      accept: "application/json, */*"
-    },
+    headers: Object.assign( {accept: "application/json, */*"}, this.headers),
     on: {
       error: function(response) {
         if (self.url.substring(0, 4) !== 'http')
@@ -981,7 +981,7 @@ Operation.prototype.setContentTypes = function(args, opts) {
   var definedFormParams = [];
   var definedFileParams = [];
   var body = args.body;
-  var headers = {};
+  var headers = Object.assign({}, opts.parent.options.swaggerOptions.headers);
 
   // get params from the operation and set them in definedFileParams, definedFormParams, headers
   var i;
@@ -1363,6 +1363,8 @@ SwaggerHttp.prototype.execute = function(obj) {
     this.useJQuery = obj.useJQuery;
   else
     this.useJQuery = this.isIE8();
+
+  obj = obj || {};
 
   if (obj && (typeof obj.useXHR === 'boolean') && obj.useXHR)
     return new XHRHttpClient().execute(obj);

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -313,6 +313,8 @@ var SwaggerClient = function(url, options) {
   if (options.url != null)
     this.url = options.url;
 
+  this.headers = options.headers;
+
   if (options.success != null)
     this.success = options.success;
 
@@ -340,9 +342,7 @@ SwaggerClient.prototype.build = function() {
     useXHR: this.useXHR,
     url: this.url,
     method: "get",
-    headers: {
-      accept: "application/json, */*"
-    },
+    headers: Object.assign( {accept: "application/json, */*"}, this.headers),
     on: {
       error: function(response) {
         if (self.url.substring(0, 4) !== 'http')
@@ -981,7 +981,7 @@ Operation.prototype.setContentTypes = function(args, opts) {
   var definedFormParams = [];
   var definedFileParams = [];
   var body = args.body;
-  var headers = {};
+  var headers = Object.assign({}, opts.parent.options.swaggerOptions.headers);
 
   // get params from the operation and set them in definedFileParams, definedFormParams, headers
   var i;
@@ -1363,6 +1363,8 @@ SwaggerHttp.prototype.execute = function(obj) {
     this.useJQuery = obj.useJQuery;
   else
     this.useJQuery = this.isIE8();
+
+  obj = obj || {};
 
   if (obj && (typeof obj.useXHR === 'boolean') && obj.useXHR)
     return new XHRHttpClient().execute(obj);

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -30,7 +30,8 @@
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
 
   <script type="text/javascript">
-    const DEFAULT_API_VERSION_URL = "/versions";
+    const API_VERSION_URL = "/versions";
+    const LOOKER_APPID_HEADER = Object.freeze({'x-looker-appid': 'Looker API Explorer'});
 
     function loadSwaggerUI(api_versioned_swagger_url) {
       return new Promise(function (resolve, reject) {
@@ -38,6 +39,7 @@
           url: api_versioned_swagger_url,
           dom_id: "swagger-ui-container",
           supportedSubmitMethods: ['get', 'post', 'put', 'patch', 'delete'],
+          headers: LOOKER_APPID_HEADER,
           // This onComplete will also be called by subsequent
           // swaggerUi.updateSwaggerUi calls
           onComplete: function(swaggerApi, swaggerUi){
@@ -80,13 +82,14 @@
       $('#login').mouseenter(function(){window.updateLoginButton()});
 
       new Promise(function (resolve, reject) {
-        return fetch(DEFAULT_API_VERSION_URL)
-          .then(function (response) {
-            if (response.status == '404')
-              reject(response.statusText);
-            else
-              resolve(response.json());
-          })
+        return fetch(API_VERSION_URL, {
+          headers: Object.assign({}, LOOKER_APPID_HEADER),
+        }).then(function (response) {
+          if (response.status === 404)
+            reject(response.statusText);
+          else
+            resolve(response.json());
+        })
       }).then(function(versionJson) {
         window.swagger_versions = versionJson.supported_versions.reduce((hash, v) => {
           hash[v.version] = v


### PR DESCRIPTION
for better attribution of API calls made via API Explorer.

Decorating the User-Agent header value would be more seamless, but it appears that Chrome browser doesn't allow changing the User-Agent header.